### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SNKit은 iOS 앱을 위한 효율적인 이미지 캐싱 및 다운로드 라이
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/jeoungsung12/SNKit.git", .exact("1.1.0"))
+    .package(url: "https://github.com/jeoungsung12/SNKit.git", .exact("1.2.0"))
 ]
 ```
 

--- a/Sources/SNKit/Utilities/ImageLoadingTask.swift
+++ b/Sources/SNKit/Utilities/ImageLoadingTask.swift
@@ -1,0 +1,31 @@
+//
+//  ImageLoadingTask.swift
+//  SNKit
+//
+//  Created by 정성윤 on 6/4/25.
+//
+
+import Foundation
+
+public final class ImageLoadingTask {
+    private let url: URL
+    private var isCancelled = false
+    private let logger = Logger(subsystem: "com.snkit", category: "ImageLoadingTask")
+    
+    init(url: URL) {
+        self.url = url
+    }
+    
+    public func cancel() {
+        isCancelled = true
+        logger.debug("이미지 로딩 작업 취소: \(url.absoluteString)")
+    }
+    
+    var isValid: Bool {
+        return !isCancelled
+    }
+    
+    func matches(url: URL) -> Bool {
+        return self.url.absoluteString == url.absoluteString
+    }
+}

--- a/Sources/SNKit/Utilities/ObjectAssociation.swift
+++ b/Sources/SNKit/Utilities/ObjectAssociation.swift
@@ -1,0 +1,21 @@
+//
+//  ObjectAssociation.swift
+//  SNKit
+//
+//  Created by 정성윤 on 6/4/25.
+//
+
+import Foundation
+
+final class ObjectAssociation<T> {
+    private let policy = objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+    
+    subscript(index: AnyObject) -> T? {
+        get {
+            return objc_getAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque()) as? T
+        }
+        set {
+            objc_setAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque(), newValue, policy)
+        }
+    }
+}

--- a/Sources/SNKit/Utilities/UIImageView + Extension.swift
+++ b/Sources/SNKit/Utilities/UIImageView + Extension.swift
@@ -8,7 +8,20 @@
 import UIKit
 
 public extension UIImageView {
+    private static var currentImageURLAssociation = ObjectAssociation<URL>()
+    private static var currentTaskAssociation = ObjectAssociation<ImageLoadingTask>()
+
+    private var snCurrentImageURL: URL? {
+        get { return Self.currentImageURLAssociation[self] }
+        set { Self.currentImageURLAssociation[self] = newValue }
+    }
+
+    private var snCurrentTask: ImageLoadingTask? {
+        get { return Self.currentTaskAssociation[self] }
+        set { Self.currentTaskAssociation[self] = newValue }
+    }
     
+    @discardableResult
     func snSetImage(
         with url: URL,
         headers: RequestHeaders? = nil,
@@ -16,26 +29,54 @@ public extension UIImageView {
         storageOption: StorageOption? = nil,
         processingOption: ImageProcessingOption = .none,
         completion: ((Result<UIImage,Error>) -> Void)? = nil
-    ) {
-        let storageOpt = storageOption ?? SNKit.shared.defaultStorageOption
+    ) -> ImageLoadingTask {
+        snCurrentTask?.cancel()
+
+        let newTask = ImageLoadingTask(url: url)
+        snCurrentTask = newTask
+        snCurrentImageURL = url
         
+        let storageOpt = storageOption ?? SNKit.shared.defaultStorageOption
+
         if let cacheImage = SNKit.shared.cachedImage(for: url),
            cacheOption == .cacheFirst {
+
             if processingOption != .none {
-                DispatchQueue.global(qos: .userInitiated).async {
+                DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                    guard newTask.isValid,
+                          newTask.matches(url: url),
+                          self?.snCurrentTask === newTask else {
+                        return
+                    }
+                    
                     let imageProcessor = ImageProcessor()
                     let processedImage = imageProcessor.process(cacheImage, with: processingOption) ?? cacheImage
                     
-                    DispatchQueue.main.async {
-                        self.image = processedImage
+                    DispatchQueue.main.async { [weak self] in
+                        guard self?.snCurrentImageURL == url,
+                              self?.snCurrentTask === newTask,
+                              newTask.isValid else {
+                            return
+                        }
+                        
+                        self?.image = processedImage
                         completion?(.success(processedImage))
                     }
                 }
             } else {
-                self.image = cacheImage
-                completion?(.success(cacheImage))
+                DispatchQueue.main.async { [weak self] in
+                    guard self?.snCurrentImageURL == url,
+                          self?.snCurrentTask === newTask,
+                          newTask.isValid else {
+                        return
+                    }
+                    
+                    self?.image = cacheImage
+                    completion?(.success(cacheImage))
+                }
             }
-            return
+            
+            return newTask
         }
         
         SNKit.shared.loadImage(
@@ -45,15 +86,53 @@ public extension UIImageView {
             storageOption: storageOption,
             processingOption: processingOption
         ) { [weak self] result in
+
+            guard let self = self,
+                  self.snCurrentImageURL == url,
+                  self.snCurrentTask === newTask,
+                  newTask.isValid else {
+                return
+            }
+            
             switch result {
             case .success(let image):
-                self?.image = image
-                completion?(.success(image))
+                DispatchQueue.main.async {
+                    guard self.snCurrentImageURL == url,
+                          self.snCurrentTask === newTask,
+                          newTask.isValid else {
+                        return
+                    }
+                    
+                    self.image = image
+                    completion?(.success(image))
+                }
             case .failure(let error):
-                completion?(.failure(error))
+                DispatchQueue.main.async {
+                    guard self.snCurrentImageURL == url,
+                          self.snCurrentTask === newTask,
+                          newTask.isValid else {
+                        return
+                    }
+                    
+                    completion?(.failure(error))
+                }
             }
         }
         
+        return newTask
     }
     
+    func snCancelImageLoading() {
+        snCurrentTask?.cancel()
+        snCurrentTask = nil
+        snCurrentImageURL = nil
+    }
+    
+    func snIsLoading(url: URL) -> Bool {
+        guard let currentURL = snCurrentImageURL,
+              let task = snCurrentTask else {
+            return false
+        }
+        return currentURL.absoluteString == url.absoluteString && task.isValid
+    }
 }


### PR DESCRIPTION
빠른 스크롤 시 셀 재사용으로 인한 잘못된 이미지 표시
취소되지 않은 이미지 로딩 작업으로 인한 메모리 누수
->  URL 매칭 + Task 검증 + 취소 상태 확인, 새 이미지 로딩 시 이전 작업 자동 취소